### PR TITLE
fix: Cypress 10 testFiles option is no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ From command palette select command `Cypress: Find not used Cucumber step defini
 -   get `cypressHelper.commandForOpen`;
 -   open terminal with name `CypressOpen`;
 -   send command `%%commandForOpen%% --config testFiles=%%spec%%` to terminal, where `%%spec%%` is opened test file path;
+    (`testFiles` option is deprecated in Cypress 10, pass `--e2e` option to previous command to have `specPattern=%%spec%%` support)
 -   after terminal `CypressOpen` is closed - deletes from opened test file all `@focus` or `.only` tags;
 
 ![](./assets/openCypress.gif)

--- a/src/openSpecFile.js
+++ b/src/openSpecFile.js
@@ -34,12 +34,16 @@ exports.openSpecFile = (type, filename) => {
 
     const terminal = getTerminal(root);
     terminal.show();
+    const commandArguments = commandForOpen.includes('--e2e')
+        ? `--config specPattern="${absolutePath}"`
+        : `--config testFiles="${absolutePath}"`;
+
     const exec =
         type === 'run'
             ? { command: commandForRun, arg: `--spec "${relativePath}"` }
             : {
                   command: commandForOpen,
-                  arg: `--config testFiles="${absolutePath}"`
+                  arg: commandArguments
               };
     terminal.sendText(`${exec.command} ${exec.arg}`);
 };


### PR DESCRIPTION
This fix ensures that cypressHelper.commandForOpen works in cypress 10 and also doesn't break the previous cypress version. Only prerequisites is to add `--e2e` to commandForOpen so it looks like `npx cypress open --e2e`

fixes issue #9